### PR TITLE
Refactor search query based on search_input.dict

### DIFF
--- a/src/api/endpoints/helpers_tools/db.py
+++ b/src/api/endpoints/helpers_tools/db.py
@@ -24,34 +24,14 @@ def prepare_query_plant_name_text(name_text):
 
 
 def prepare_search_query(search_input: SearchIn) -> dict:
-    query_and = []
-    if search_input.name_text:
-        query_and.append(prepare_query_plant_name_text(search_input.name_text))
-    if search_input.flowering_seasons:
-        query_and.append({"flowering_seasons": {"$in": search_input.flowering_seasons}})
-    if search_input.colors:
-        query_and.append({"colors": {"$in": search_input.colors}})
-    if search_input.location_names:
-        for location_name in search_input.location_names:
-            query_and.append({"locations.location_name": location_name})
-    if search_input.petals:
-        query_and.append({"petal_num": {"$in": search_input.petals}})
-    if search_input.life_forms:
-        query_and.append({"life_forms": {"$in": search_input.life_forms}})
-    if search_input.habitats:
-        query_and.append({"habitats": {"$in": search_input.habitats}})
-    if search_input.stem_shapes:
-        query_and.append({"stem_shapes": {"$in": search_input.stem_shapes}})
-    if search_input.spine:
-        query_and.append({"spine": {"$in": search_input.spine}})
-    if search_input.red:
-        query_and.append({"red": search_input.red})
-    if search_input.invasive:
-        query_and.append({"invasive": search_input.invasive})
-    if search_input.danger:
-        query_and.append({"danger": search_input.danger})
-    if search_input.rare:
-        query_and.append({"rare": search_input.rare})
+    query_and = [prepare_query_plant_name_text(search_input.name_text)] if search_input.name_text else []
+    for field, value in search_input.dict(exclude_none=True, exclude_unset=True).items():
+        if field == 'location_names':
+            query_and += [{"locations.location_name": location_name} for location_name in value]
+        elif isinstance(value, list):
+            query_and += [{field: {'$in': value}}]
+        elif isinstance(value, bool):
+            query_and += [{field: value}]
 
     if not query_and:
         raise HTTPException(

--- a/src/api/endpoints/helpers_tools/db.py
+++ b/src/api/endpoints/helpers_tools/db.py
@@ -26,6 +26,8 @@ def prepare_query_plant_name_text(name_text):
 def prepare_search_query(search_input: SearchIn) -> dict:
     query_and = [prepare_query_plant_name_text(search_input.name_text)] if search_input.name_text else []
     for field, value in search_input.dict(exclude_none=True, exclude_unset=True).items():
+        if field == 'petals':
+            field = 'petal_num'
         if field == 'location_names':
             query_and += [{"locations.location_name": location_name} for location_name in value]
         elif isinstance(value, list):


### PR DESCRIPTION
Please notice - this will fail one test:

>tests/api/test_plant.py::TestSearch::test_search_with_multi_params[params0-2] FAILED

~~As far as i'm able to see this is not a problem with this function, the problem is with the old function (which passed tests by mistake)~~

As a bonus, the old function did something like this:

    if search_input.red:
        query_and.append({"red": search_input.red})

This means that the condition is `True` and appended, or `None`/`False` and not appended at all (you can not append `{"red": False}` even if `search_input.red == False`

~~This specific tests will need to be changed (or even better, add a test to explicitly see if this is the case)~~

Closes #4 