### PR TITLE
Create docker image for API

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -1,0 +1,19 @@
+name: API Docker Image build test
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'src/api/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'src/api/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build src/api --file src/api/Dockerfile --tag encyclo-flower-api-test:$(date +%s)

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,40 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+env:
+  DOCKER_IMAGE_NAME: ohad24/${{ github.event.repository.name }}
+
+jobs:
+  build_push_docker_hub:
+    name: Build & Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Build the Docker image
+        run: docker build src/api --file src/api/Dockerfile --tag ${DOCKER_IMAGE_NAME}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.DOCKER_IMAGE_NAME }}
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/src/api/.dockerignore
+++ b/src/api/.dockerignore
@@ -1,0 +1,7 @@
+__pycache__
+*.pyc
+
+google_cred.json
+GOOGLE_APPLICATION_CREDENTIALS.json
+
+docker-compose.yml

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.10-slim 
+
+ARG USERNAME=appuser
+ARG APPDIR=/app
+
+# These env variables should be provided in deployment
+ENV MONGO_DB_NAME=
+ENV MONGO_URI=
+ENV GOOGLE_APPLICATION_CREDENTIALS=
+
+WORKDIR ${APPDIR}
+COPY . ${APPDIR}
+
+RUN useradd --no-create-home --home-dir=${APPDIR} ${USERNAME} \
+  && chown -R ${USERNAME}:${USERNAME} ${APPDIR}
+
+RUN python -m pip install --upgrade --no-cache-dir pip \
+  && pip install --upgrade --no-cache-dir -r ${APPDIR}/requirements.txt
+
+ENV PYTHONPATH=${APPDIR}
+
+USER ${USERNAME}
+EXPOSE 8000
+CMD [ "uvicorn", "main:app", "--host=0.0.0.0" ]


### PR DESCRIPTION
Changes:
- Added `Dockerfile` and .dockerignore to api folder
- moved `docker-compose.yml` from db folder to api folder, deleted db folder (using it in the same place allows one command to deploy the entire environment)

Notice:
-  This image must still have `google_cred.json` set as external volume, see #18 
- Tested the API only with "hello-world", did not load any data into the database (but i don't see any reason why that wouldn't work as is)
- `.env` in this folder is ignored in `.gitignore` so `COMPOSE_PROJECT_NAME=ENCYCLO-FLOWER` has to be inserted manually (or it should be removed from `.gitignore`)