### PR TITLE
remove gcloud auth from workflows

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -32,13 +32,12 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - id: 'auth'
-      name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v0'
-      with:
-        credentials_json: '${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}'
     - name: Test with pytest
       env:
         MONGO_URI: ${{ secrets.MONGO_URI }}
+        GOOGLE_CRED_RAW: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+        GOOGLE_APPLICATION_CREDENTIALS: GOOGLE_APPLICATION_CREDENTIALS.json
       run: |
+        echo $GOOGLE_CRED_RAW > GOOGLE_APPLICATION_CREDENTIALS.json
         pytest tests/api/
+        rm GOOGLE_APPLICATION_CREDENTIALS.json


### PR DESCRIPTION
This will remove the gcloud auth step from the testing workflow

This step is only necessary because the "secret" creds are not a file, this workflow now creates a file so that step isn't needed

Dependabot will stop failing on this step because it doesn't exist, and your test can already handle non-existing credentials