### PR TITLE
limit tests to api paths

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,13 +1,19 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python application
+name: API pytest
 
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'src/api/**'
+      - 'tests/api/**'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/api/**'
+      - 'tests/api/**'
 
 jobs:
   build:


### PR DESCRIPTION
I'm about to add server/host definitions, ansible, gcp and stuff like that, no point in tests running when the api or tests aren't updated