### PR TITLE
Metadata deployment

### DIFF
--- a/server/deploy.sh
+++ b/server/deploy.sh
@@ -1,5 +1,18 @@
 #!/bin/sh
 
-cd ${HOME}
-docker compose pull
-docker compose up -d --remove-orphans
+gcp_metadata_json_to_env() {
+    # This function is used to get metadata from the GCP metadata server and write it to a file
+    # The value is expected to be in json format and the output will be a .env file
+    # The first parameter is the metadata key to retrieve
+    # The second parameter is the file to write the metadata to
+    METADATA_URL='http://metadata.google.internal/computeMetadata/v1/project/attributes'
+    curl -fsL "${METADATA_URL}/${1}" -H "Metadata-Flavor: Google" | jq -r "to_entries|map(\"\(.key)=\(.value|tostring)\")|.[]" > "${2}"
+}
+
+# Ensure .env files are updated before deploying
+gcp_metadata_json_to_env "PRODUCTION" "${HOME}/PRODUCTION.env"
+gcp_metadata_json_to_env "DEVELOPMENT" "${HOME}/DEVELOPMENT.env"
+
+DOCKER_COMPOSE_YML="${HOME}/docker-compose.yml"
+docker compose -f ${DOCKER_COMPOSE_YML} pull
+docker compose -f ${DOCKER_COMPOSE_YML} up -d --remove-orphans

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -31,8 +31,7 @@ services:
     image: ohad24/encyclo-flower-api:latest
     restart: always
     env_file:
-      # FIXME: api.env should have production variables, currently has test variables
-      - api.env
+      - PRODUCTION.env
     volumes:
       - ./google_cred.json:/app/google_cred.json
     networks:
@@ -42,7 +41,7 @@ services:
     image: ohad24/encyclo-flower-api:edge
     restart: always
     env_file:
-      - api-dev.env
+      - DEVELOPMENT.env
     volumes:
       - ./google_cred.json:/app/google_cred.json
     networks:

--- a/server/playbook.yml
+++ b/server/playbook.yml
@@ -112,12 +112,14 @@
         path: "{{ stack_user.home }}/{{ item }}"
         owner: "{{ stack_user.name }}"
         group: "{{ stack_user.group }}"
-        mode: 0440
+        mode: 0640  # Read/write for owner, read only for group
+        state: touch
       loop:
         - .env
-        - api.env
-        - api-dev.env
+        - PRODUCTION.env
+        - DEVELOPMENT.env
         - google_cred.json
+      changed_when: false  # Do not consider this a change
 
     - name: Set up deployment key
       ansible.posix.authorized_key:

--- a/server/playbook.yml
+++ b/server/playbook.yml
@@ -131,8 +131,18 @@
         - "{{ stack_user.name }}"
         - "{{ ansible_user.name }}"
 
-    - name: Run docker services
-      community.docker.docker_compose:
-        project_src: "{{ stack_user.home }}"
-        pull: yes
-        remove_orphans: yes
+    - name: Run deployment script
+      # This replaces the previous method of running docker compose directly
+      shell:
+        chdir: "{{ stack_user.home }}"
+        cmd: "sudo -u {{ stack_user.name }} sh {{ stack_user.home }}/deploy.sh"
+        warn: no  # Disable sudo warning
+      changed_when: false  # Do not consider this a change
+
+    - name: Cronjob for deployment
+      cron:
+        name: "{{ stack_user.name }}-deploy"
+        user: "{{ stack_user.name }}"
+        minute: "*/15" # Every 15 minutes
+        job: "sh {{ stack_user.home }}/deploy.sh"
+        state: present


### PR DESCRIPTION
Changes:
- Ansible will run the full `deploy.sh` script instead of just `docker compose up`
- `deploy.sh` now includes updating the `*.env` files from gcp metadata
- Added cronjob for `deploy.sh` every 15 minutes (will be set up through ansible)
- Changed `*.env` file permissions to be writable because they need to be updated
- Changed `*.env` filenames to be more general because they will not be used only for api
